### PR TITLE
Fix webpack build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,5 @@ jobs:
       script: npm run lint
     - name: 'Test'
       script: npm test
+    - name: 'Build'
+      script: npm run build

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,13 +6,19 @@ module.exports = {
   target: 'node',
   mode: 'production',
   devtool: 'inline-source-map',
-  entry: path.resolve(__dirname, 'src', 'server.ts'),
+  entry: path.resolve(__dirname, 'src', 'index.ts'),
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'dist'),
   },
   module: {
-    rules: [{ test: /\.ts$/, use: ['babel-loader', 'ts-loader'], exclude: /node_modules/ }],
+    rules: [
+      {
+        test: /\.ts$/,
+        use: ['babel-loader', 'ts-loader'],
+        exclude: /node_modules/,
+      },
+    ],
   },
   resolve: {
     extensions: ['.ts', '.js'],


### PR DESCRIPTION
The removal of the express app saw the main entry file change from `src/server.ts` to `src/index.ts`, but the webpack config was not updated accordingly. Adjust the config to succeed at building the application, and add the build script to Travis so similar issue will be caught by CI in the future.